### PR TITLE
Fix mold-linker scripts

### DIFF
--- a/src/mold-linker/install.sh
+++ b/src/mold-linker/install.sh
@@ -115,7 +115,7 @@ find_prev_version_from_git_tags() {
 # Fetches .tar.gz file
 install_tgz_using_github() {
     check_packages wget tar
-    arch=$(dpkg --print-architecture)
+    arch=$(uname -m)
 
     find_version_from_git_tags MOLD_VERSION https://github.com/rui314/mold
     mold_filename="mold-${MOLD_VERSION}-${arch}-linux"
@@ -149,7 +149,7 @@ export DEBIAN_FRONTEND=noninteractive
 check_packages curl ca-certificates apt-transport-https
 if ! type git > /dev/null 2>&1; then
     check_packages git
-fi~
+fi
 
 # Soft version matching
 if [ "${MOLD_VERSION}" != "latest" ] && [ "${MOLD_VERSION}" != "lts" ] && [ "${MOLD_VERSION}" != "stable" ]; then

--- a/test/mold-linker/test.sh
+++ b/test/mold-linker/test.sh
@@ -79,7 +79,8 @@ find_prev_version_from_git_tags() {
 }
 
 MOLD_VERSION="2.4.0"
+
 find_prev_version_from_git_tags MOLD_VERSION https://github.com/rui314/mold
-check "pre-version-to-2.4.0" bash -c "echo ${MOLD_VERSION} | grep '2.4.0'"
+check "pre-version-to-2.4.0" bash -c "echo ${MOLD_VERSION} | grep '2.3.3'"
 
 reportResults


### PR DESCRIPTION
Mold linker install scripts had some typos and functionality issues.

This PR should fully fix it as it now passes local testing.

## Change Overview
- install.sh: Package architecture names originally provided by dpkg however mold releases use uname format.
- install.sh: had a `fi~` Fixes failing lint checks in #3
- test.sh: I misunderstood how devcontainers/features was checking pre-version's, All tests now pass :)